### PR TITLE
Modified package.json to specifically depend on coffee-script 1.2.0 fixes #2

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
    },
    "dependencies" : {
        "binpack" : "*",
-       "coffee-script" : ">=1.2.0"
+       "coffee-script" : "1.2.0"
    },
    "devDependencies" : {
        "expresso" : "*",


### PR DESCRIPTION
1.3.0 breaks a bunch of stuff as you will notice in my earlier posted issue.  While a proper fix will update the codebase to support 1.3.0, this keeps stuff working for now.
