### PR TITLE
Fix timetags

### DIFF
--- a/examples/oscbundle_heartbeat.coffee
+++ b/examples/oscbundle_heartbeat.coffee
@@ -10,9 +10,12 @@ if process.argv[2]?
 else
     outport = 41234
 
+# unix timestamp in seconds with fractional
+start = (new Date()).getTime() / 1000;
+
 sendHeartbeat = () ->
     buf = osc.toBuffer(
-        timetag : 0.001  # 0.001 seconds from now
+        timetag : start + 0.05  # 0.05 seconds from now
         elements : [
             {
                 address : "/p1"
@@ -23,7 +26,7 @@ sendHeartbeat = () ->
                 args : "string"
             }
             {
-                timetag: 34567
+                timetag: start + 1  # 1 second from now
                 elements : [
                     {
                         address : "/p3"

--- a/examples/oscbundle_heartbeat.coffee
+++ b/examples/oscbundle_heartbeat.coffee
@@ -12,7 +12,7 @@ else
 
 sendHeartbeat = () ->
     buf = osc.toBuffer(
-        timetag : 12345
+        timetag : 0.001  # 0.001 seconds from now
         elements : [
             {
                 address : "/p1"

--- a/lib/index.js
+++ b/lib/index.js
@@ -84,7 +84,7 @@
 //               elements : [element1, element]
 //           }
 //
-//   `oscType` ("bundle"|"message")
+//   `oscType` "bundle"
 //
 //   `timetag` is one of:
 //    `null` - meaning now, the current time.
@@ -186,8 +186,7 @@
 //
 // Received OSC bundles converted with `fromBuffer` will have a timetag array:
 // [secondsSince1970, fractionalSeconds]
-// This utility is useful for logging. Accuracy is reduced to milliseconds,
-// but the returned Date object also has `fractionalSecondsInt` and `fractionalSecondsFloat` set if you need full accuracy (0.00000000023283 second, or 2^32 per second)
+// This utility is useful for logging. Accuracy is reduced to milliseconds.
   exports.timetagToDate = utils.timetagToDate;
 
 //~api~

--- a/lib/index.js
+++ b/lib/index.js
@@ -76,7 +76,7 @@
 //    `string`, `float`, `array` or `blob`, depending on its javascript type
 //    (String, Number, Array, Buffer, respectively)
 //
-// + An _OSC Bundle_ is represented as a javascript object with the following layout
+// + An _OSC Bundle_ is represented as a javascript object with the following fields:
 //
 //           {
 //               oscType : "bundle"
@@ -84,12 +84,24 @@
 //               elements : [element1, element]
 //           }
 //
-//   Where the timetag is a javascript-native numeric value of the timetag,
-//   and elements is an array of either an _OSC Bundle_ or an _OSC Message_
-//   The `oscType` field is optional, but is always returned by api functions.
+//   `oscType` ("bundle"|"message")
+//
+//   `timetag` is one of:
+//    `null` - meaning now, the current time.
+//      By the time the bundle is received it will too late and depending
+//      on the receiver may be discarded or you may be scolded for being late.
+//    `number` - relative seconds from now with millisecond accuracy.
+//    `Date` - a JavaScript Date object in your local time zone.
+//     OSC timetags use UTC timezone, so do not try to adjust for timezones,
+//     this is not needed.
+//    `Array` - [numberOfSecondsSince1900, fractionalSeconds]
+//      Both values are Int32. This gives full timing accuracy of 1/(2^32) seconds which may be needed for some granular synthesis applications.
+//
+//  `elements` is an Array of either _OSC Message_ or _OSC Bundle_
+//
 //
 // [spec]: http://opensoundcontrol.org/spec-1_0
-  
+
   var utils, coffee;
   utils = require("./osc-utilities");
 // ~api~
@@ -165,5 +177,33 @@
   exports.applyMessageTransform = function(buffer, transform) {
     return utils.applyTransform(buffer, utils.messageTransform(transform));
   };
+
+
+//~api~
+//----
+//### .timetagToDate(ntpTimeTag)
+// Convert a timetag array to a JavaScript Date object in your local timezone.
+//
+// Received OSC bundles converted with `fromBuffer` will have a timetag array:
+// [secondsSince1970, fractionalSeconds]
+// This utility is useful for logging. Accuracy is reduced to milliseconds,
+// but the returned Date object also has `fractionalSecondsInt` and `fractionalSecondsFloat` set if you need full accuracy (0.00000000023283 second, or 2^32 per second)
+  exports.timetagToDate = utils.timetagToDate;
+
+//~api~
+//----
+//### .dateToTimetag(date)
+// Convert a JavaScript Date to a NTP timetag array [secondsSince1970, fractionalSeconds].
+//
+// `toBuffer` already accepts Dates for timetags so you might not need this function. If you need to schedule bundles with finer than millisecond accuracy then you could use this to help assemble the NTP array.
+  exports.dateToTimetag = utils.dateToTimetag;
+
+//~api~
+//----
+//### .deltaTimetag(secondsFromNow, [now])
+// Make NTP timetag array relative to the current time.
+//
+// `toBuffer` already accepts floats for timetags and interprets this as a relative time, so you might not need this function. If you need to schedule bundles with finer than millisecond accuracy then you could use this to help assemble the NTP array.
+  exports.deltaTimetag = utils.deltaTimetag;
 
 }).call(this);

--- a/lib/index.js
+++ b/lib/index.js
@@ -203,7 +203,6 @@
 //### .deltaTimetag(secondsFromNow, [now])
 // Make NTP timetag array relative to the current time.
 //
-// `toBuffer` already accepts floats for timetags and interprets this as a relative time, so you might not need this function. If you need to schedule bundles with finer than millisecond accuracy then you could use this to help assemble the NTP array.
   exports.deltaTimetag = utils.deltaTimetag;
 
 }).call(this);

--- a/lib/osc-utilities.coffee
+++ b/lib/osc-utilities.coffee
@@ -210,7 +210,7 @@ exports.ntpToFractionalSeconds = (fracSeconds) ->
 # as a Buffer for adding to an OSC bundle.
 exports.toTimetagBuffer = (timetag) ->
   if typeof timetag is "number"
-    timetag = exports.deltaTimetag(timetag)
+    timetag = exports.timestampToTimetag(timetag)
   else if typeof timetag is "object" and ("getTime" of timetag)
     # quacks like a Date
     timetag = exports.dateToTimetag(timetag)

--- a/lib/osc-utilities.coffee
+++ b/lib/osc-utilities.coffee
@@ -189,10 +189,6 @@ exports.timetagToDate = (timetag) ->
   dd.setUTCMinutes(date.getUTCMinutes())
   dd.setUTCSeconds(date.getUTCSeconds())
   dd.setUTCMilliseconds(fracs * 1000)
-  # set fractional seconds with full precision
-  # to date object
-  dd.fractionalSecondsInt = fractional
-  dd.fractionalSecondsFloat = fracs
   return dd
 
 # Make NTP timestamp array for relative future: now + seconds

--- a/lib/osc-utilities.coffee
+++ b/lib/osc-utilities.coffee
@@ -156,12 +156,11 @@ TWO_POW_32 = 4294967296
 # Time zone of the Date object is respected, as the NTP
 # timetag uses UTC.
 exports.dateToTimetag = (date) ->
-  return exports.timestampToTimetag(date.getTime())
+  return exports.timestampToTimetag(date.getTime() / 1000)
 
-# Convert a unix timestamp (milliseconds since jan 1 1970)
+# Convert a unix timestamp (seconds since jan 1 1970 UTC)
 # to NTP timestamp array
-exports.timestampToTimetag = (timestamp) ->
-  secs = timestamp / 1000
+exports.timestampToTimetag = (secs) ->
   wholeSecs = Math.floor(secs)
   fracSeconds = secs - wholeSecs
   return makeTimetag(wholeSecs, fracSeconds)
@@ -197,10 +196,10 @@ exports.timetagToDate = (timetag) ->
   return dd
 
 # Make NTP timestamp array for relative future: now + seconds
-# Accuracy is limited to 1 millisecond
+# Accuracy of 'now' limited to milliseconds but 'seconds' may be a full 32 bit float
 exports.deltaTimetag = (seconds, now) ->
-  d = (now ? new Date()) * 1 + (seconds * 1000)
-  return exports.timestampToTimetag(d)
+  n = (now ? new Date()) / 1000
+  return exports.timestampToTimetag(n + seconds)
 
 # Convert 32 bit int for NTP fractional seconds
 # to a 32 bit float

--- a/lib/osc-utilities.coffee
+++ b/lib/osc-utilities.coffee
@@ -129,6 +129,99 @@ exports.splitInteger = (buffer, type) ->
 
   return {integer : value, rest : rest}
 
+# Split off an OSC timetag from buffer
+# returning {timetag: [seconds, fractionalSeconds], rest: restOfBuffer}
+exports.splitTimetag = (buffer) ->
+  type = "Int32"
+  bytes = (binpack["pack" + type] 0).length
+
+  if buffer.length < (bytes * 2)
+    throw new Error "buffer is not big enough to contain a timetag"
+
+  # integers are stored in big endian format.
+  a = 0
+  b = bytes
+  seconds = binpack["unpack" + type] buffer[a...b], "big"
+  c = bytes
+  d = bytes + bytes
+  fractional = binpack["unpack" + type] buffer[c...d], "big"
+  rest = buffer[d...(buffer.length)]
+
+  return {timetag: [seconds, fractional], rest: rest}
+
+UNIX_EPOCH = 2208988800
+TWO_POW_32 = 4294967296
+
+# Convert a JavaScript Date to a NTP timetag array.
+# Time zone of the Date object is respected, as the NTP
+# timetag uses UTC.
+exports.dateToTimetag = (date) ->
+  return exports.timestampToTimetag(date.getTime())
+
+# Convert a unix timestamp (milliseconds since jan 1 1970)
+# to NTP timestamp array
+exports.timestampToTimetag = (timestamp) ->
+  secs = timestamp / 1000
+  wholeSecs = Math.floor(secs)
+  fracSeconds = secs - wholeSecs
+  return makeTimetag(wholeSecs, fracSeconds)
+
+makeTimetag = (unixseconds, fracSeconds) ->
+  # NTP epoch is 1900, JavaScript Date is unix 1970
+  ntpSecs = unixseconds + UNIX_EPOCH
+  ntpFracs = Math.round(TWO_POW_32 * fracSeconds)
+  return [ntpSecs, ntpFracs]
+
+# Convert NTP timestamp array to a JavaScript Date
+# in your systems local time zone.
+exports.timetagToDate = (timetag) ->
+  [seconds, fractional] = timetag
+  seconds = seconds - UNIX_EPOCH
+  fracs = exports.ntpToFractionalSeconds(fractional)
+  date = new Date()
+  # Sets date to UTC/GMT
+  date.setTime((seconds * 1000) + (fracs * 1000))
+  # Create a local timezone date
+  dd = new Date()
+  dd.setUTCFullYear(date.getUTCFullYear())
+  dd.setUTCMonth(date.getUTCMonth())
+  dd.setUTCDate(date.getUTCDate())
+  dd.setUTCHours(date.getUTCHours())
+  dd.setUTCMinutes(date.getUTCMinutes())
+  dd.setUTCSeconds(date.getUTCSeconds())
+  dd.setUTCMilliseconds(fracs * 1000)
+  # set fractional seconds with full precision
+  # to date object
+  dd.fractionalSecondsInt = fractional
+  dd.fractionalSecondsFloat = fracs
+  return dd
+
+# Make NTP timestamp array for relative future: now + seconds
+# Accuracy is limited to 1 millisecond
+exports.deltaTimetag = (seconds, now) ->
+  d = (now ? new Date()) * 1 + (seconds * 1000)
+  return exports.timestampToTimetag(d)
+
+# Convert 32 bit int for NTP fractional seconds
+# to a 32 bit float
+exports.ntpToFractionalSeconds = (fracSeconds) ->
+  return parseFloat(fracSeconds) / TWO_POW_32
+
+# Encodes a timetag of type null|Number|Array|Date
+# as a Buffer for adding to an OSC bundle.
+exports.toTimetagBuffer = (timetag) ->
+  if typeof timetag is "number"
+    timetag = exports.deltaTimetag(timetag)
+  else if typeof timetag is "object" and ("getTime" of timetag)
+    # quacks like a Date
+    timetag = exports.dateToTimetag(timetag)
+  else if timetag.length != 2
+    throw new Error("Invalid timetag" + timetag)
+  type = "Int32"
+  high = binpack["pack" + type] timetag[0], "big"
+  low = binpack["pack" + type] timetag[1], "big"
+  return exports.concat([high, low])
+
 exports.toIntegerBuffer = (number, type) ->
   type = "Int32" if not type?
   if typeof number isnt "number"
@@ -164,11 +257,10 @@ oscTypeCodes =
   t : {
     representation : "timetag"
     split : (buffer, strict) ->
-      split = exports.splitInteger buffer, "UInt64"
-      {value : split.integer, rest : split.rest}
+      split = exports.splitTimetag buffer
+      {value: split.timetag, rest: split.rest}
     toArg : (value, strict) ->
-      throw new Error "expected number" if typeof value isnt "number"
-      exports.toIntegerBuffer value, "UInt64"
+      exports.toTimetagBuffer value
   }
   f : {
     representation : "float"
@@ -388,8 +480,8 @@ exports.fromOscBundle = (buffer, strict) ->
   if bundleTag isnt "\#bundle"
     throw new Error "osc-bundles must begin with \#bundle"
 
-  # grab the 8 - bit timetag
-  { integer : timetag, rest : buffer} = exports.splitInteger buffer, "UInt64"
+  # grab the 8 byte timetag
+  {timetag: timetag, rest: buffer} = exports.splitTimetag buffer
 
   # convert each element.
   convertedElems = mapBundleList buffer, (buffer) ->
@@ -480,7 +572,7 @@ exports.toOscBundle = (bundle, strict) ->
   # the bundle must have timetag and elements.
   if strict and not bundle?.timetag?
     throw StrictError "bundles must have timetags."
-  timetag =  bundle?.timetag ? 0
+  timetag =  bundle?.timetag ? new Date()
   elements = bundle?.elements ? []
   if not IsArray elements
     elemstr = elements
@@ -488,7 +580,7 @@ exports.toOscBundle = (bundle, strict) ->
     elements.push elemstr
 
   oscBundleTag = exports.toOscString "\#bundle"
-  oscTimeTag = exports.toIntegerBuffer timetag, "UInt64"
+  oscTimeTag = exports.toTimetagBuffer timetag
 
   oscElems = []
   for elem in elements

--- a/test/test-osc-utilities.coffee
+++ b/test/test-osc-utilities.coffee
@@ -768,7 +768,7 @@ test 'timetagToDate converts timetag to a Date', ->
 
 test 'timestampToTimetag converts a unix time to ntp array', ->
   date = new Date()
-  timetag = osc.timestampToTimetag(date.getTime())
+  timetag = osc.timestampToTimetag(date.getTime() / 1000)
   date2 = osc.timetagToDate(timetag)
   assertDatesEqual date, date2
 


### PR DESCRIPTION
Fixes #11 - NTP timetag should be two Int32 …
Previously timetags were encoding JavaScript numbers (which are max 32 bit) as a
64 bit Int which means all time tags were still trapped in the first second of
January 1, 1900.

Now supports:

nil (immediate)
float (seconds from now)
Date (millisecond accurate)
Array `[secondsSince1900, fractionalSeconds]` (0.00000000023283 second accuracy)

Technically this is a breaking change, but I don't think anybody could have used the timestamps before. 
The one thing that is different is that incoming bundles converted with `fromBuffer` will now have an array as the timestamp instead of a number. But the previous number was just the picoseconds anyway.

This also adds some utilities that people can use to convert the timetag to a Date for logging; but it doesn't automatically waste CPU doing that for every incoming bundle.