### PR TITLE
expand compatibility of TypedBufferLike

### DIFF
--- a/lib/osc-utilities.ts
+++ b/lib/osc-utilities.ts
@@ -1,5 +1,5 @@
 export type TypedBufferLike = {
-  buffer: ArrayBuffer;
+  buffer: ArrayBufferLike;
   byteOffset: number;
   byteLength: number;
 };


### PR DESCRIPTION
In reference to some discussion [in this old issue](https://github.com/russellmcc/node-osc-min/issues/29) the node dgram socket `message` event returns a `Buffer<ArrayBufferLike>` which is not currently type compatible with the `TypedBufferLike` as it only would accepts a `Buffer<ArrayBuffer>`.

I don't see any issues with this type change as `ArrayBufferLike` is just `ArrayBuffer | SharedArrayBuffer`.